### PR TITLE
setup.py: add python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,13 @@ setup(name='hashids',
       author_email='dev@david-aurelio.com',
       url='https://github.com/davidaurelio/hashids-python',
       license='MIT License',
-      py_modules=('hashids',))
+      py_modules=('hashids',),
+      classifiers=[
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.2',
+          'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: 3.4',
+      ],)


### PR DESCRIPTION
These classifiers are the only way I have found to programmatically
know which python version is supported by a given package. This
information is useful if you write tools to isolate and reduce your
codebase dependency to python 2.