### PR TITLE
Workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,33 @@
+name: Upload Python Package
+
+on: [create, push]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pep517
+    - name: Build sdist and bdist
+      run: |
+        python -m pep517.build --binary --source --out-dir dist .
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      if: startsWith(github.ref, 'refs/tags/v')
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Adds a github workflow to automate publishing to PyPI for tags. As a first test, each commit publishes to `test.pypi.org` only.